### PR TITLE
Add gem5 setup procedure to 'on_create.py'

### DIFF
--- a/.devcontainer/on_create.sh
+++ b/.devcontainer/on_create.sh
@@ -9,3 +9,13 @@ gem5-x86 gem5_stubgen.py
 gem5-riscv gem5_stubgen.py
 
 mv out typings
+
+# Setups the gem5 source directory
+cd gem5
+
+## We cleanup git's 'blame' feature by ignoring certain commits (typically
+## commits that have reformatted files)
+git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+
+## `git pull` should rebase by default
+git config --global pull.rebase true


### PR DESCRIPTION
This sets up the gem5 git environment to:

1. Utilize the .git-black-ignore-revs file.
2. Rebase on a pull request.