### PR TITLE
Remove UniqueCacheHierarchy from simulator-use

### DIFF
--- a/materials/using-gem5/02-stdlib/complete/clever-simulator-use-complete.py
+++ b/materials/using-gem5/02-stdlib/complete/clever-simulator-use-complete.py
@@ -1,16 +1,14 @@
 from gem5.components.boards.simple_board import SimpleBoard
 from gem5.components.memory.single_channel import SingleChannelDDR3_1600
+from gem5.components.cachehierarchies.classic.no_cache import NoCache
 from gem5.components.processors.simple_processor import SimpleProcessor
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.resources.resource import CustomResource
 from gem5.simulate.simulator import Simulator
 from gem5.simulate.exit_event import ExitEvent
 
-from unique_cache_hierarchy.unique_cache_hierarchy_complete import UniqueCacheHierarchy
-
-
 # Obtain the components.
-cache_hierarchy = UniqueCacheHierarchy()
+cache_hierarchy = NoCache()
 
 memory = SingleChannelDDR3_1600("1GiB")
 processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, num_cores=1)

--- a/materials/using-gem5/02-stdlib/complete/simple-simulator-use-complete.py
+++ b/materials/using-gem5/02-stdlib/complete/simple-simulator-use-complete.py
@@ -1,15 +1,13 @@
 from gem5.components.boards.simple_board import SimpleBoard
 from gem5.components.memory.single_channel import SingleChannelDDR3_1600
+from gem5.components.cachehierarchies.classic.no_cache import NoCache
 from gem5.components.processors.simple_processor import SimpleProcessor
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.resources.resource import CustomResource
 from gem5.simulate.simulator import Simulator
 
-from unique_cache_hierarchy.unique_cache_hierarchy_complete import UniqueCacheHierarchy
-
-
 # Obtain the components.
-cache_hierarchy = UniqueCacheHierarchy()
+cache_hierarchy = NoCache()
 
 memory = SingleChannelDDR3_1600("1GiB")
 processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, num_cores=1)

--- a/materials/using-gem5/02-stdlib/simulator-use.py
+++ b/materials/using-gem5/02-stdlib/simulator-use.py
@@ -1,15 +1,13 @@
 from gem5.components.boards.simple_board import SimpleBoard
 from gem5.components.memory.single_channel import SingleChannelDDR3_1600
+from gem5.components.cachehierarchies.classic.no_cache import NoCache
 from gem5.components.processors.simple_processor import SimpleProcessor
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.resources.resource import CustomResource
 from gem5.simulate.simulator import Simulator
 
-from unique_cache_hierarchy.unique_cache_hierarchy_complete import UniqueCacheHierarchy
-
-
 # Obtain the components.
-cache_hierarchy = UniqueCacheHierarchy()
+cache_hierarchy = NoCache()
 
 memory = SingleChannelDDR3_1600("1GiB")
 processor = SimpleProcessor(cpu_type=CPUTypes.ATOMIC, num_cores=1)


### PR DESCRIPTION
The simulator-use.py file (used in the stdlib tutorial) utilized the the
UniqueCacheHierarchy. This doesn't work when teaching and has been
replaced with NoCache.

The complete examples reflect this change